### PR TITLE
Fix status script disabled when only "Check status on startup" is checked

### DIFF
--- a/contents/ui/config.qml
+++ b/contents/ui/config.qml
@@ -165,7 +165,7 @@ Item {
                 Layout.column: 1
                 id: checkStatusScriptText
                 Layout.minimumWidth: 300
-                enabled: statusScriptEnabledBox.checked
+                enabled: (statusScriptEnabledBox.checked ||  runStatusScriptBox.checked)
             }
             
             Label {


### PR DESCRIPTION
When "Check status on startup" is checked but "Run periodically" isn't, the script will run but you cannot edit the field. This fixes it.

Does not affect whether script runs or not, only changes the UI in config